### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Wrapper for Android Preferences which provides a fluid syntax.
 
 ## Usage
 This library is really easy to use.
-####Download
+#### Download
 ```GROOVY
 compile 'me.alexrs:prefs:1.1.0'
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
